### PR TITLE
style: polish UI and improve hover states on portfolio components

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -178,7 +178,7 @@ export default async function Page() {
 
             {/* Right Column - Avatar */}
             <div className="flex justify-center md:justify-end">
-              <div className="relative">
+              <div className="relative hover:scale-[1.02] transition-transform hover:shadow-2xl rounded-full">
                 <Avatar className="size-64 md:size-72 border-2">
                   <AvatarImage alt={DATA.name} src={DATA.avatarUrl} />
                   <AvatarFallback>{DATA.initials}</AvatarFallback>
@@ -312,7 +312,7 @@ export default async function Page() {
             </h2>
           </div>
 
-          <div className="space-y-6">
+          <div className="space-y-6 relative flex w-full flex-col overflow-hidden [mask-image:linear-gradient(to_right,transparent,black_10%,black_90%,transparent)]">
             {/* AI/ML Row - Left to Right */}
             <Marquee className="py-4" pauseOnHover fade magnify>
               {aiMlSkills.map((skill) => (

--- a/src/components/work-experience-section.tsx
+++ b/src/components/work-experience-section.tsx
@@ -43,7 +43,7 @@ export function WorkExperienceSection({ work }: WorkExperienceSectionProps) {
             className={`text-left ${idx === 0 ? "md:col-span-2" : ""}`}
           >
             <MagicCard
-              className="p-6 cursor-pointer transition-all duration-300 hover:scale-[1.02] h-full rounded-2xl border border-border/40 hover:border-accent/50"
+              className="p-6 cursor-pointer transition-all duration-300 hover:scale-[1.02] h-full rounded-2xl border border-border/40 hover:border-accent/50 hover:shadow-lg dark:hover:shadow-accent/20 hover:bg-accent/5"
               gradientColor="#5B122D"
               gradientColorDark="#d4a5a5"
               gradientOpacity={0.15}


### PR DESCRIPTION
This PR polishes the UI components of the main page and work experience section.
Specifically:
1.  **Avatar:** Added a subtle scale animation (`hover:scale-[1.02]`) and drop shadow (`hover:shadow-2xl`) on hover to make it feel more interactive.
2.  **Skills Marquee:** Wrapped the skills section in a linear gradient mask (`mask-image`) to make the badges smoothly fade out at the edges rather than getting cut off abruptly.
3.  **Work Experience Cards:** Enhanced the hover state of the `MagicCard` components with an increased shadow (`hover:shadow-lg`) and a subtle background tint (`hover:bg-accent/5`) to provide more depth and feedback when interacting with them.

---
*PR created automatically by Jules for task [2781564086173198204](https://jules.google.com/task/2781564086173198204) started by @adhishthite*